### PR TITLE
performance(streamer-wrapper): memoize streamer cards

### DIFF
--- a/app/[locale]/(feat)/dashboard/page.tsx
+++ b/app/[locale]/(feat)/dashboard/page.tsx
@@ -4,8 +4,8 @@ import {getServerSession} from "next-auth";
 import {ContentLayout} from "@/components/dashboard/content-layout";
 import {StreamerWrapperSkeleton} from "@/app/[locale]/(feat)/streamers/components/streamer-wrapper-skeleton";
 import StatsCardWrapper from "@/app/[locale]/(feat)/(stats)/stats-card-wrapper";
-import StreamerWrapper from "@/app/[locale]/(feat)/streamers/components/streamer-wrapper";
 import {useTranslations} from "next-intl";
+import {StreamerWrapper} from "@/app/[locale]/(feat)/streamers/components/streamer-wrapper";
 
 export async function generateMetadata({params: {locale}}: { params: { locale: string } }) {
   const t = await getTranslations({locale, namespace: 'Metadata'});

--- a/app/[locale]/(feat)/streamers/components/streamer-wrapper.tsx
+++ b/app/[locale]/(feat)/streamers/components/streamer-wrapper.tsx
@@ -1,11 +1,10 @@
-'use server'
-import React from "react";
+import React, {useMemo} from "react";
 import {deleteStreamer, fetchStreamers} from "@/lib/data/streams/streamer-apis";
 import {StreamerCardProps} from "@/app/[locale]/(feat)/streamers/components/streamer";
 import {StreamerSchema} from "@/lib/data/streams/definitions";
-import {getFormatter, getTranslations} from "next-intl/server";
 import {StreamerStatusList} from "@/app/[locale]/(feat)/streamers/components/streamer-status-list";
 import {WS_API_URL} from "@/lib/data/events/events-api";
+import {useFormatter, useTranslations} from "next-intl";
 
 type StreamerWrapperProps = {
   recordingString: string;
@@ -15,7 +14,7 @@ type StreamerWrapperProps = {
 
 // use hook to pass down streamer data to client card
 // I don't want to create a next intl provider, so a server hook is used
-export const toStreamerCards = async (streamers: StreamerSchema[], t: any, format: any) => {
+export const toStreamerCards = (streamers: StreamerSchema[], t: any, format: any) => {
   const formatLastStream = (streamer: StreamerSchema) => {
     if (streamer.isActivated && streamer.isLive) {
       return t('liveNow')
@@ -45,20 +44,30 @@ export const toStreamerCards = async (streamers: StreamerSchema[], t: any, forma
 }
 
 
-export default async function StreamerWrapper({recordingString, inactiveString, disabledString}: StreamerWrapperProps) {
-  const totalStreamers = await fetchStreamers('non-template'), disabledStreamers = totalStreamers.filter(streamer => !streamer.isActivated),
-      activeStreamers = totalStreamers.filter(streamer => streamer.isActivated),
-      recordingStreamers = activeStreamers.filter(streamer => streamer.isLive),
-      inactiveStreamers = activeStreamers.filter(streamer => !streamer.isLive);
+export function StreamerWrapper({recordingString, inactiveString, disabledString}: StreamerWrapperProps) {
 
-  const t = await getTranslations('StreamerData');
-  const contextMenuT = await getTranslations('OpenVideoContextMenu');
+  const fetchPromise = fetchStreamers('non-template')
 
-  const format = await getFormatter()
+  const totalStreamers = React.use(fetchPromise);
+
+  const {disabledStreamers, activeStreamers, recordingStreamers, inactiveStreamers} = useMemo(() => {
+    const disabledStreamers = totalStreamers.filter(streamer => !streamer.isActivated),
+        activeStreamers = totalStreamers.filter(streamer => streamer.isActivated),
+        recordingStreamers = activeStreamers.filter(streamer => streamer.isLive),
+        inactiveStreamers = activeStreamers.filter(streamer => !streamer.isLive);
+    return {disabledStreamers, activeStreamers, recordingStreamers, inactiveStreamers}
+  }, [totalStreamers])
+
+  const t = useTranslations('StreamerData');
+  const contextMenuT = useTranslations('OpenVideoContextMenu');
+
+  const format = useFormatter()
 
   const toCards = (schemas: StreamerSchema[]) => toStreamerCards(schemas, t, format);
 
-  const [recordingCards, disabledCards, inactiveCards] = await Promise.all([toCards(recordingStreamers), toCards(disabledStreamers), toCards(inactiveStreamers)])
+  const [recordingCards, disabledCards, inactiveCards] = useMemo(() => {
+    return [toCards(recordingStreamers), toCards(disabledStreamers), toCards(inactiveStreamers)]
+  }, [recordingStreamers, disabledStreamers, inactiveStreamers])
 
   return (
       <>


### PR DESCRIPTION

- Replace import `React` with `{useMemo}` and remove `use server`
- Change `toStreamerCards` from asynchronous to synchronous function
- Supplant `async function StreamerWrapper` with `function StreamerWrapper`
- Replace `await fetchStreamers` with `React.use(fetchPromise)`
- Optimize the setting of streamers' data using `useMemo`
- Replace `await getTranslations` and `await getFormatter` with `useTranslations` and `useFormatter` respectively
- Wrap `toCards` in `useMemo` to optimize performance
- Fix StreamerWrapper import in dashboard page.tsx to match with new export pattern in streamer-wrapper.tsx