### PR TITLE
feat(user): hash passwords with md5 before sending to API

### DIFF
--- a/lib/data/user/user-apis.ts
+++ b/lib/data/user/user-apis.ts
@@ -1,14 +1,20 @@
 'use server'
 
 import {fetchApi} from "@/lib/data/api";
+import {createHash} from 'crypto';
+
+const hashMd5 = (input: string): string => {
+  return createHash('md5').update(input).digest('hex');
+};
 
 export const login = async (username: string, password: string) => {
+  const hashedPassword = hashMd5(password)
   const response = await fetchApi('/auth/login', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({username, password})
+    body: JSON.stringify({username, password: hashedPassword})
   })
 
   if (!response.ok) {


### PR DESCRIPTION
- add `createHash` import from `crypto`
- introduce `hashMd5` function to hash passwords
- update `login` function to send hashed password