### PR TITLE
feat(copy-action): add support for copying files

### DIFF
--- a/app/[locale]/(feat)/streamers/components/actions/action-card.tsx
+++ b/app/[locale]/(feat)/streamers/components/actions/action-card.tsx
@@ -3,7 +3,7 @@ import {Switch} from "@/components/new-york/ui/switch";
 import {Separator} from "@/components/new-york/ui/separator";
 import {DeleteIcon, EditIcon} from "lucide-react";
 import React from "react";
-import {ActionSchema, ActionType, CommandActionSchema, MoveActionSchema, RcloneActionSchema} from "@/lib/data/actions/definitions";
+import {ActionSchema, ActionType, CommandActionSchema, CopyActionSchema, MoveActionSchema, RcloneActionSchema} from "@/lib/data/actions/definitions";
 import {NewActionDialog, NewActionDialogStrings} from "@/app/[locale]/(feat)/streamers/components/actions/new-action-dialog";
 import {DeleteIconDialog} from "@/app/components/dialog/delete-icon-dialog";
 import {Button} from "@/components/new-york/ui/button";
@@ -44,13 +44,17 @@ export function ActionCard({data, onCheckedChange, onEdit, onDelete, actionStrin
           <CardContent>
             <div className={"flex flex-col justify-between space-y-1 w-full"}>
               <p className="text-sm text-slate-500">
-                {data.type === ActionType.Command ? (data as CommandActionSchema).program : data.type === ActionType.Rclone ? (data as RcloneActionSchema).rcloneOperation : ""}
+                {data.type === ActionType.Command ? (data as CommandActionSchema).program :
+                    data.type === ActionType.Rclone ? (data as RcloneActionSchema).rcloneOperation : ""}
               </p>
               <p className="text-sm text-slate-500 max-w-35 break-words">
-                {data.type === ActionType.Rclone ? (data as RcloneActionSchema).remotePath : ""}
+                {data.type === ActionType.Rclone && (data as RcloneActionSchema).remotePath}
               </p>
               <p className="text-sm text-slate-500 max-w-35 break-words">
-                {data.type === ActionType.Move ? (data as MoveActionSchema).destination : ""}
+                {data.type === ActionType.Move && (data as MoveActionSchema).destination}
+              </p>
+              <p className="text-sm text-slate-500 max-w-35 break-words">
+                {data.type === ActionType.Copy && (data as CopyActionSchema).destination}
               </p>
 
               {

--- a/app/[locale]/(feat)/streamers/components/actions/form/copy-form.tsx
+++ b/app/[locale]/(feat)/streamers/components/actions/form/copy-form.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {copyActionSchema, CopyActionSchema} from "@/lib/data/actions/definitions";
+import React, {forwardRef} from "react";
+import {SubmitHandler, useForm} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage} from "@/components/new-york/ui/form";
+import {Input} from "@/components/new-york/ui/input";
+
+export type CopyFormProps = {
+  defaultValues: CopyActionSchema
+  strings: {
+    destination: string,
+    destinationDefault: string,
+    destinationDescription: string
+  },
+  onSubmit: (data: CopyActionSchema) => void
+}
+
+
+export const CopyActionForm = forwardRef<HTMLFormElement, CopyFormProps>(({defaultValues, strings, onSubmit}, ref) => {
+
+  const form = useForm(
+      {
+        resolver: zodResolver(copyActionSchema),
+        defaultValues: defaultValues
+      }
+  )
+
+  const handleSubmit: SubmitHandler<CopyActionSchema> = (data) => {
+    onSubmit(data)
+  }
+
+  return <>
+    <Form {...form}>
+      <form ref={ref} onSubmit={event => {
+        event.preventDefault()
+        form.handleSubmit(handleSubmit)()
+        event.stopPropagation()
+      }
+      }>
+        <FormField control={form.control} name={"destination"} render={({field}) => (
+            <FormItem>
+              <FormLabel>{strings.destination}</FormLabel>
+              <FormControl>
+                <Input placeholder={strings.destinationDefault} {...field}/>
+              </FormControl>
+              <FormDescription>
+                {strings.destinationDescription}
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+        )}>
+        </FormField>
+      </form>
+    </Form>
+  </>
+})
+
+CopyActionForm.displayName = "CopyActionForm"

--- a/app/[locale]/(feat)/streamers/components/actions/new-action-dialog.tsx
+++ b/app/[locale]/(feat)/streamers/components/actions/new-action-dialog.tsx
@@ -1,11 +1,5 @@
 import {Button} from "@/components/new-york/ui/button"
-import {
-  ActionSchema,
-  ActionType,
-  CommandActionSchema,
-  MoveActionSchema,
-  RcloneActionSchema
-} from "@/lib/data/actions/definitions";
+import {ActionSchema, ActionType, CommandActionSchema, CopyActionSchema, MoveActionSchema, RcloneActionSchema} from "@/lib/data/actions/definitions";
 import {FormMessage} from "@/components/new-york/ui/form";
 import React, {useCallback, useRef} from "react";
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/new-york/ui/select";
@@ -26,6 +20,7 @@ import {CommandActionForm} from "@/app/[locale]/(feat)/streamers/components/acti
 import {RcloneActionForm} from "@/app/[locale]/(feat)/streamers/components/actions/form/rclone-form";
 import {MoveActionForm} from "@/app/[locale]/(feat)/streamers/components/actions/form/move-form";
 import {DeleteActionForm} from "@/app/[locale]/(feat)/streamers/components/actions/form/delete-action-form";
+import {CopyActionForm} from "@/app/[locale]/(feat)/streamers/components/actions/form/copy-form";
 
 type NewActionDialogProps = {
   strings: NewActionDialogStrings
@@ -71,6 +66,14 @@ export type NewActionDialogStrings = {
     destinationDefault: string,
     destinationDescription: string
   },
+
+  copyStrings: {
+    title: string,
+    destination: string,
+    destinationDefault: string,
+    destinationDescription: string
+  },
+
   removeStrings: {
     title: string
   }
@@ -136,7 +139,9 @@ export function NewActionDialog({strings, openIcon, defaultValues = defaultActio
       }}/>,
       [ActionType.Remove]: <DeleteActionForm {...formProps} />,
       [ActionType.Move]: <MoveActionForm {...formProps} defaultValues={formProps.defaultValues as MoveActionSchema}
-                                         strings={strings.moveStrings}/>
+                                         strings={strings.moveStrings}/>,
+      [ActionType.Copy]: <CopyActionForm {...formProps} defaultValues={formProps.defaultValues as CopyActionSchema}
+                                         strings={strings.copyStrings}/>
     };
 
     return forms[type] || null;
@@ -178,6 +183,7 @@ export function NewActionDialog({strings, openIcon, defaultValues = defaultActio
             <SelectContent>
               <SelectItem value={ActionType.Command}>{strings.commandStrings.title}</SelectItem>
               <SelectItem value={ActionType.Rclone}>{strings.rcloneStrings.title}</SelectItem>
+              <SelectItem value={ActionType.Copy}>{strings.copyStrings.title}</SelectItem>
               <SelectItem value={ActionType.Move}>{strings.moveStrings.title}</SelectItem>
               <SelectItem value={ActionType.Remove}>{strings.removeStrings.title}</SelectItem>
             </SelectContent>

--- a/app/[locale]/(feat)/streamers/components/streamer-form-wrapper.tsx
+++ b/app/[locale]/(feat)/streamers/components/streamer-form-wrapper.tsx
@@ -47,6 +47,7 @@ export function StreamerFormWrapper({templateData, defaultStreamerValues, onSubm
   const commandT = useTranslations("Command")
   const removeT = useTranslations("RemoveAction")
   const moveT = useTranslations("MoveAction")
+  const copyT = useTranslations("CopyAction")
 
 
   return <>
@@ -155,7 +156,13 @@ export function StreamerFormWrapper({templateData, defaultStreamerValues, onSubm
               destination: moveT("destination"),
               destinationDefault: moveT("destinationDefault"),
               destinationDescription: moveT("destinationDescription")
-            }
+            },
+            copyStrings: {
+              title: copyT("title"),
+              destination: copyT("destination"),
+              destinationDefault: copyT("destinationDefault"),
+              destinationDescription: copyT("destinationDescription")
+            },
           }
         }
       }

--- a/lib/data/actions/definitions.ts
+++ b/lib/data/actions/definitions.ts
@@ -4,7 +4,8 @@ export enum ActionType {
   Command = "command",
   Rclone = "rclone",
   Remove = "remove",
-  Move = "move"
+  Move = "move",
+  Copy = "copy"
 }
 
 
@@ -39,9 +40,15 @@ export const moveActionSchema = baseActionSchema.extend({
   destination: z.string().min(1),
 })
 
+export const copyActionSchema = baseActionSchema.extend({
+  type: z.literal(ActionType.Copy),
+  destination: z.string().min(1),
+})
+
 export type BaseActionSchema = z.infer<typeof baseActionSchema>
 export type CommandActionSchema = z.infer<typeof commandActionSchema>
 export type RcloneActionSchema = z.infer<typeof rcloneActionSchema>
 export type RemoveActionSchema = z.infer<typeof removeActionSchema>
 export type MoveActionSchema = z.infer<typeof moveActionSchema>
-export type ActionSchema = CommandActionSchema | RcloneActionSchema | RemoveActionSchema | MoveActionSchema
+export type CopyActionSchema = z.infer<typeof copyActionSchema>
+export type ActionSchema = CommandActionSchema | RcloneActionSchema | RemoveActionSchema | MoveActionSchema | CopyActionSchema

--- a/lib/data/streams/definitions.ts
+++ b/lib/data/streams/definitions.ts
@@ -1,5 +1,5 @@
 import {z} from "zod";
-import {commandActionSchema, moveActionSchema, rcloneActionSchema, removeActionSchema} from "@/lib/data/actions/definitions";
+import {commandActionSchema, copyActionSchema, moveActionSchema, rcloneActionSchema, removeActionSchema} from "@/lib/data/actions/definitions";
 import {twitchRegex} from "@/lib/data/platform/twitch/constants";
 import {huyaRegex} from "@/lib/data/platform/huya/constants";
 import {douyinRegex} from "@/lib/data/platform/douyin/constants";
@@ -7,6 +7,8 @@ import {douyuRegex} from "@/lib/data/platform/douyu/constants";
 import {pandatvRegex} from "@/lib/data/platform/pandatv/constants";
 
 export const videoFormats = ["mp4", "avi", "mov", "mkv", "flv", "ts"] as const;
+
+const actionSchema = rcloneActionSchema.or(commandActionSchema).or(removeActionSchema).or(moveActionSchema).or(copyActionSchema);
 
 export const baseDownloadConfig = z.object({
   type: z.string().nullish(),
@@ -17,9 +19,10 @@ export const baseDownloadConfig = z.object({
   outputFileName: z.string().nullish(),
   outputFileExtension: z.enum(videoFormats).nullish(),
   outputFileFormat: z.string().nullish(),
-  onPartedDownload: rcloneActionSchema.or(commandActionSchema).or(removeActionSchema).or(moveActionSchema).array().nullish(),
-  onStreamingFinished: rcloneActionSchema.or(commandActionSchema).or(removeActionSchema).or(moveActionSchema).array().nullish(),
+  onPartedDownload: actionSchema.array().nullish(),
+  onStreamingFinished: actionSchema.array().nullish(),
 })
+
 export type DownloadConfig = z.infer<typeof baseDownloadConfig>
 
 export const streamDataSchema = z.object({

--- a/messages/en.json
+++ b/messages/en.json
@@ -99,6 +99,12 @@
     "destinationDescription": "Destination folder to move.",
     "destinationDefault": "Enter a destination folder"
   },
+  "CopyAction": {
+    "title": "Copy",
+    "destination": "Destination",
+    "destinationDescription": "Destination folder to copy.",
+    "destinationDefault": "Enter a destination folder"
+  },
   "RemoveAction": {
     "title": "Remove"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -100,6 +100,12 @@
     "destinationDescription": "目标文件路径",
     "destinationDefault": "请输入目标文件路径"
   },
+  "copyAction": {
+    "title": "复制文件",
+    "destination": "目标文件",
+    "destinationDescription": "目标文件路径",
+    "destinationDefault": "请输入目标文件路径"
+  },
   "RemoveAction": {
     "title": "删除文件"
   },


### PR DESCRIPTION
- Add `CopyActionSchema` to action definitions
- Implement `CopyActionForm` component
- Update `streamer-form-wrapper`, `new-action-dialog`, and `action-card` to support the new copy action
- Add copy action strings to `en.json` and `zh.json`